### PR TITLE
Add opam compatibility testing tool to MCP server

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -9,7 +9,9 @@ documentation dataset through the Model Context Protocol (MCP) using HTTP SSE.
 import json
 import logging
 from pathlib import Path
-from typing import Dict, Any, Optional
+from typing import Dict, Any, Optional, List
+import subprocess
+import shlex
 
 from mcp.server.fastmcp import FastMCP
 
@@ -79,6 +81,73 @@ async def find_ocaml_packages(functionality: str) -> Dict[str, Any]:
         return {"error": error_msg}
 
 
+@mcp.tool()
+async def test_opam_compatibility(packages: List[str]) -> Dict[str, Any]:
+    """
+    Test opam package compatibility for a list of packages.
+    
+    Runs 'opam list --installable --all-versions -s' to find concrete package 
+    versions that are compatible with the current switch.
+
+    Requires the current opam switch for the project to be the active one.
+    
+    Args:
+        packages: List of opam package names to test for compatibility
+    
+    Returns:
+        Dictionary containing the list of compatible package versions and any errors
+    """
+    if not packages:
+        return {"error": "No packages provided"}
+    
+    # Join packages with spaces and ensure proper escaping
+    package_list = " ".join(shlex.quote(pkg) for pkg in packages)
+    cmd = f"opam list --installable --all-versions -s {package_list}"
+    
+    logger.info(f"Running opam compatibility test: {cmd}")
+    
+    try:
+        # Run the opam command
+        result = subprocess.run(
+            cmd,
+            shell=True,
+            capture_output=True,
+            text=True,
+            timeout=30  # 30 second timeout
+        )
+        
+        if result.returncode != 0:
+            return {
+                "error": f"opam command failed with exit code {result.returncode}",
+                "stderr": result.stderr.strip()
+            }
+        
+        # Parse the output - opam list returns one package per line
+        output_lines = result.stdout.strip().split('\n')
+        compatible_versions = []
+        
+        for line in output_lines:
+            line = line.strip()
+            if line and not line.startswith('#'):  # Skip comments and empty lines
+                compatible_versions.append(line)
+        
+        return {
+            "packages_tested": packages,
+            "compatible_versions": compatible_versions,
+            "count": len(compatible_versions)
+        }
+        
+    except subprocess.TimeoutExpired:
+        return {
+            "error": "opam command timed out after 30 seconds",
+            "packages_tested": packages
+        }
+    except Exception as e:
+        error_msg = f"Failed to run opam command: {str(e)}"
+        logger.error(error_msg)
+        return {"error": error_msg}
+
+
 # Additional tool functions can be added here using the @mcp.tool() decorator
 # Example structure for future tools:
 #
@@ -104,10 +173,18 @@ def main():
     if len(sys.argv) > 1 and sys.argv[1] == "--test":
         # Run a simple test
         async def test():
-            query = sys.argv[2] if len(sys.argv) > 2 else "HTTP server"
-            print(f"Testing query: {query}\n")
-            result = await find_ocaml_packages(query)
-            print(json.dumps(result, indent=2))
+            if len(sys.argv) > 2 and sys.argv[2] == "opam":
+                # Test opam compatibility
+                packages = sys.argv[3:] if len(sys.argv) > 3 else ["base", "core"]
+                print(f"Testing opam compatibility for: {packages}\n")
+                result = await test_opam_compatibility(packages)
+                print(json.dumps(result, indent=2))
+            else:
+                # Test search functionality
+                query = sys.argv[2] if len(sys.argv) > 2 else "HTTP server"
+                print(f"Testing search query: {query}\n")
+                result = await find_ocaml_packages(query)
+                print(json.dumps(result, indent=2))
         
         asyncio.run(test())
     else:


### PR DESCRIPTION
Added test_opam_compatibility function that runs 'opam list --installable --all-versions -s' to check which package versions are compatible with the current switch. Enhanced test mode to support both search and opam testing.

🤖 Generated with [Claude Code](https://claude.ai/code)